### PR TITLE
Ref/lotties with hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,14 +19,13 @@
     "@emotion/styled": "^11",
     "firebase": "^8.8.1",
     "framer-motion": "^4",
+    "lottie-react": "^2.1.0",
     "next": "11.1.0",
     "react": "17.0.2",
-    "react-dom": "17.0.2",
-    "react-lottie": "^1.2.3"
+    "react-dom": "17.0.2"
   },
   "devDependencies": {
     "@types/react": "17.0.15",
-    "@types/react-lottie": "^1.2.6",
     "eslint": "7.31.0",
     "eslint-config-next": "11.0.1",
     "eslint-config-prettier": "^8.3.0",

--- a/packages/components/Lottie.tsx
+++ b/packages/components/Lottie.tsx
@@ -1,17 +1,19 @@
-import LottieComponent, { Options } from 'react-lottie';
+import { useLottie, LottieOptions, CSSProperties } from 'lottie-react';
 
-import * as avocadoAnimation from '@packages/assets/lotties/404.json';
+import avocadoAnimation from '@packages/assets/lotties/404.json';
 
-interface LottieProps {
-  animation: AvaiableAnimations;
-}
+const style = {
+  width: '70%',
+};
 
 export default function Lottie(props: LottieProps) {
   const options = processOptions(props);
+  const { View } = useLottie(options, style);
+  return View;
+}
 
-  return (
-    <LottieComponent options={options} width="70%" isClickToPauseDisabled />
-  );
+interface LottieProps {
+  animation: AvaiableAnimations;
 }
 
 type AvaiableAnimations = 'avocado';
@@ -20,12 +22,10 @@ const lottieAnimations: Record<AvaiableAnimations, Object> = {
   avocado: avocadoAnimation,
 };
 
-function processOptions(props: LottieProps): Options {
+function processOptions(props: LottieProps): LottieOptions {
   return {
-    loop: false,
     animationData: lottieAnimations[props.animation],
-    rendererSettings: {
-      preserveAspectRatio: 'xMidYMid slice',
-    },
+    loop: true,
+    autoplay: true,
   };
 }

--- a/packages/components/Lottie.tsx
+++ b/packages/components/Lottie.tsx
@@ -1,19 +1,17 @@
-import { useLottie, LottieOptions, CSSProperties } from 'lottie-react';
+import { CSSProperties } from 'react';
+import { useLottie, LottieOptions } from 'lottie-react';
 
 import avocadoAnimation from '@packages/assets/lotties/404.json';
 
-const style = {
-  width: '70%',
-};
-
 export default function Lottie(props: LottieProps) {
   const options = processOptions(props);
-  const { View } = useLottie(options, style);
+  const { View } = useLottie(options, props.styles);
   return View;
 }
 
 interface LottieProps {
   animation: AvaiableAnimations;
+  styles: CSSProperties;
 }
 
 type AvaiableAnimations = 'avocado';

--- a/packages/components/NotFound.tsx
+++ b/packages/components/NotFound.tsx
@@ -25,7 +25,7 @@ export default function NotFound() {
         <Text color="gray.500" maxW="3xl">
           Mas encontramos esse abacate!
         </Text>
-        <Lottie animation="avocado" />
+        <Lottie animation="avocado" styles={{ width: '70%' }} />
       </Stack>
     </Box>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1258,26 +1258,19 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"
   integrity sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==
 
-"@types/react-lottie@^1.2.6":
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/@types/react-lottie/-/react-lottie-1.2.6.tgz#4f351dfdf5f93a46a3a9714fbb319f1e0f030eaf"
-  integrity sha512-fvGJHD7SeUdVESHo7f7erRnXkTWaa/6Mo5TB+R0/ieSftKoFspA4sMlF2qMH6BljXI7ehFJbBtrD5bzDxPCkGg==
-  dependencies:
-    "@types/react" "*"
-
-"@types/react@*", "@types/react@^17.0.0":
-  version "17.0.19"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.19.tgz#8f2a85e8180a43b57966b237d26a29481dacc991"
-  integrity sha512-sX1HisdB1/ZESixMTGnMxH9TDe8Sk709734fEQZzCV/4lSu9kJCPbo2PbTRoZM+53Pp0P10hYVyReUueGwUi4A==
+"@types/react@17.0.15":
+  version "17.0.15"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.15.tgz#c7533dc38025677e312606502df7656a6ea626d0"
+  integrity sha512-uTKHDK9STXFHLaKv6IMnwp52fm0hwU+N89w/p9grdUqcFA6WuqDyPhaWopbNyE1k/VhgzmHl8pu1L4wITtmlLw==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
-"@types/react@17.0.15":
-  version "17.0.15"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.15.tgz#c7533dc38025677e312606502df7656a6ea626d0"
-  integrity sha512-uTKHDK9STXFHLaKv6IMnwp52fm0hwU+N89w/p9grdUqcFA6WuqDyPhaWopbNyE1k/VhgzmHl8pu1L4wITtmlLw==
+"@types/react@^17.0.0":
+  version "17.0.19"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.19.tgz#8f2a85e8180a43b57966b237d26a29481dacc991"
+  integrity sha512-sX1HisdB1/ZESixMTGnMxH9TDe8Sk709734fEQZzCV/4lSu9kJCPbo2PbTRoZM+53Pp0P10hYVyReUueGwUi4A==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -1547,14 +1540,6 @@ babel-plugin-macros@^2.6.1:
     "@babel/runtime" "^7.7.2"
     cosmiconfig "^6.0.0"
     resolve "^1.12.0"
-
-babel-runtime@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
-  integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
-  dependencies:
-    core-js "^2.4.0"
-    regenerator-runtime "^0.11.0"
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -1899,11 +1884,6 @@ core-js@3.6.5:
   version "3.6.5"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
   integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
-
-core-js@^2.4.0:
-  version "2.6.12"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
-  integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
 core-util-is@~1.0.0:
   version "1.0.3"
@@ -3332,7 +3312,14 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
-lottie-web@^5.1.3:
+lottie-react@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/lottie-react/-/lottie-react-2.1.0.tgz#24d20ea41dc10791b1253f408dcb6f3e995780be"
+  integrity sha512-sHDJb5aeh1letUIWqwidHoHZj07ZOZQoLuUgy0gqt9FB/XiCtAZ2+421Cn+ZkHR7anVvWljKhGgctQCtgFloUA==
+  dependencies:
+    lottie-web "^5.7.3"
+
+lottie-web@^5.7.3:
   version "5.7.13"
   resolved "https://registry.yarnpkg.com/lottie-web/-/lottie-web-5.7.13.tgz#c4087e4742c485fc2c4034adad65d1f3fcd438b0"
   integrity sha512-6iy93BGPkdk39b0jRgJ8Zosxi8QqcMP5XcDvg1f0XAvEkke6EMCl6BUO4Lu78dpgvfG2tzut4QJ+0vCrfbrldQ==
@@ -4061,14 +4048,6 @@ react-is@^16.7.0, react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-lottie@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/react-lottie/-/react-lottie-1.2.3.tgz#8544b96939e088658072eea5e12d912cdaa3acc1"
-  integrity sha512-qLCERxUr8M+4mm1LU0Ruxw5Y5Fn/OmYkGfnA+JDM/dZb3oKwVAJCjwnjkj9TMHtzR2U6sMEUD3ZZ1RaHagM7kA==
-  dependencies:
-    babel-runtime "^6.26.0"
-    lottie-web "^5.1.3"
-
 react-refresh@0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
@@ -4155,11 +4134,6 @@ readdirp@~3.5.0:
   integrity sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==
   dependencies:
     picomatch "^2.2.1"
-
-regenerator-runtime@^0.11.0:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
-  integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
 regenerator-runtime@^0.13.4:
   version "0.13.9"


### PR DESCRIPTION
# Descrição

Pessoal, fazendo a documentação de lotties e estudando um pouco mais a lib percebi que existe outro pacote NPM adequado ao React que me pareceu mais interessante do que o que estamos utilizando.

Considerações:

- [Lib antiga](https://www.npmjs.com/package/react-lottie)
- [Lib Nova](https://www.npmjs.com/package/lottie-react)

A nova é menos utilizada ao todo, porém considerando gráficos de tendência comparando as opções ela hoje é quem está na frente. Isto se dá por ser uma biblioteca mais recente.

Vocês vão perceber que a nova lib já utiliza hooks e as versões mais recentes das funcionalidades do React/JS, a documentação é mais concisa e com exemplos mais claros, além de já expor hooks para o uso de animações.

## Changes

- Remove lib antiga, instala a nova
- Troca utilização no componente, melhora suas interfaces.


