### PR TITLE
fea: create team page route

### DIFF
--- a/packages/features/i18n-context.tsx
+++ b/packages/features/i18n-context.tsx
@@ -81,4 +81,5 @@ export type TranslationNS =
   | 'mentoring'
   | 'roadmap'
   | 'social-links'
-  | 'footer';
+  | 'footer'
+  | 'team-page';

--- a/packages/locale/en.yml
+++ b/packages/locale/en.yml
@@ -67,3 +67,6 @@ footer:
 social-links:
   github: Github
   linkedin: LinkedIn
+
+team-page:
+  title: Community <span>People</span>

--- a/packages/locale/pt.yml
+++ b/packages/locale/pt.yml
@@ -70,3 +70,6 @@ footer:
 social-links:
   github: Github
   linkedin: LinkedIn
+
+team-page:
+  title: Pessoas da <span>comunidade</span>

--- a/pages/team.tsx
+++ b/pages/team.tsx
@@ -1,15 +1,14 @@
-import { Heading, Stack, Text } from '@chakra-ui/react';
+import { Heading, Flex, Text } from '@chakra-ui/react';
 import { Trans } from 'react-i18next';
 
 import { useI18n } from '@packages/features/i18n-context';
+import Section from '@packages/components/Section';
 
-import Section from '../packages/components/Section';
-
-function Team() {
+export default function Team() {
   const { t } = useI18n('team-page');
   return (
     <Section py="10rem">
-      <Stack textAlign="center" align="center" spacing={{ base: 8, md: 10 }}>
+      <Flex justifyContent="center">
         <Heading
           fontWeight={600}
           fontSize={{ base: '3xl', sm: '4xl' }}
@@ -22,9 +21,7 @@ function Team() {
             }}
           />
         </Heading>
-      </Stack>
+      </Flex>
     </Section>
   );
 }
-
-export default Team;

--- a/pages/team.tsx
+++ b/pages/team.tsx
@@ -1,0 +1,30 @@
+import { Heading, Stack, Text } from '@chakra-ui/react';
+import { Trans } from 'react-i18next';
+
+import { useI18n } from '@packages/features/i18n-context';
+
+import Section from '../packages/components/Section';
+
+function Team() {
+  const { t } = useI18n('team-page');
+  return (
+    <Section py="10rem">
+      <Stack textAlign="center" align="center" spacing={{ base: 8, md: 10 }}>
+        <Heading
+          fontWeight={600}
+          fontSize={{ base: '3xl', sm: '4xl' }}
+          lineHeight="110%"
+        >
+          <Trans
+            i18nKey={t(`title`)}
+            components={{
+              span: <Text as="span" color="purple.400" />,
+            }}
+          />
+        </Heading>
+      </Stack>
+    </Section>
+  );
+}
+
+export default Team;


### PR DESCRIPTION
- create `/team` route
- insert  Heading componente
- create page title
- translate title

# Descrição
 Create a team page with a route to `/team` and configure the page tilte in pt-br and english. 

## Changes
- create a `/team` route in `/pages` directory;
- Add a Section component in `/pages/team` with a Heading component to page title;
- Add a `team-page` section in /packages/locale/en.yml and /packages/locale/pt.yml with a title key.

this closes #74  
