### PR TITLE
FEA: add secondary button link

### DIFF
--- a/packages/components/CallToActionSection.tsx
+++ b/packages/components/CallToActionSection.tsx
@@ -4,6 +4,7 @@ import { Trans } from 'react-i18next';
 import { useModalActions } from '@packages/features/modal-context';
 import { Illustration } from '@packages/components/icons';
 import { useI18n } from '@packages/features/i18n-context';
+import { links } from '@packages/config/site';
 
 import Section from './Section';
 
@@ -43,7 +44,7 @@ export default function CallToActionSection() {
           >
             {t(`main-button`)}
           </Button>
-          <Button rounded="full" px={6}>
+          <Button as="a" href={links.secondaryButton} rounded="full" px={6}>
             {t(`secondary-button`)}
           </Button>
         </Stack>

--- a/packages/components/Section.tsx
+++ b/packages/components/Section.tsx
@@ -3,6 +3,7 @@ import { ReactNode } from 'react';
 
 interface Props extends ChakraProps {
   children: ReactNode;
+  id?: string;
 }
 
 function Section({ children, ...props }: Props) {

--- a/packages/components/WhyItWorksSection.tsx
+++ b/packages/components/WhyItWorksSection.tsx
@@ -23,7 +23,7 @@ export default function WhyItWorksSection() {
   const bgColor = useColorModeValue('gray.50', 'gray.900');
 
   return (
-    <Section bg={bgColor}>
+    <Section bg={bgColor} id="why-it-works">
       <Heading
         fontWeight={600}
         fontSize={{ base: '3xl', sm: '4xl' }}

--- a/packages/config/site.ts
+++ b/packages/config/site.ts
@@ -21,6 +21,7 @@ export const links = {
   // social
   github: 'https://github.com/podcodar',
   linkedin: 'https://www.linkedin.com/company/podcodar/',
+  secondaryButton: '#why-it-works',
 };
 
 export const roadMapsLinks = {

--- a/packages/config/site.ts
+++ b/packages/config/site.ts
@@ -17,11 +17,11 @@ export const links = {
   team: '/team',
   wiki: 'http://wiki.podcodar.com',
   forum: 'https://github.com/podcodar/forum/discussions',
+  secondaryButton: '#why-it-works',
 
   // social
   github: 'https://github.com/podcodar',
   linkedin: 'https://www.linkedin.com/company/podcodar/',
-  secondaryButton: '#why-it-works',
 };
 
 export const roadMapsLinks = {

--- a/packages/locale/en.yml
+++ b/packages/locale/en.yml
@@ -11,7 +11,7 @@ call-to-action:
     on training professionals. We exist to democratize knowledge and access to job
     opportunities in the technology area
   main-button: Join us!
-  secondary-button: How it works?
+  secondary-button: Learn more
 
 why-it-works:
   title: And why it works?

--- a/packages/locale/pt.yml
+++ b/packages/locale/pt.yml
@@ -12,11 +12,11 @@ call-to-action:
     conhecimento e o acesso às oportunidades de trabalho na área de
     tecnologia
   main-button: Faça parte!
-  secondary-button: Como funciona?
+  secondary-button: Saiba mais
 
 why-it-works:
   title: E por quê funciona?
-  practical-learn.title: Aprenda na prática
+  practical-learn.title: Aprendizado na prática
   practical-learn.description: >
     Utilizamos práticas do mercado de trabalho para acelerar seu
     desenvolvimento profissional.


### PR DESCRIPTION
# Descrição

Adiciona ação para botão secondário da página. Link envia para sessão "Why it works".

- links e traduções foram alteradas
- botão precisa usar atributo `as` para funcionar corretamente com `href`
- resolvi typo na sessão de aprendizado na pratica

it closes #48 
