### PR TITLE
FEA: add firestore bindings

### DIFF
--- a/packages/entities/members.ts
+++ b/packages/entities/members.ts
@@ -1,0 +1,25 @@
+export interface Member {
+  name: string;
+  email: string;
+  role: Role;
+  techs: Techs[];
+}
+
+export type Techs =
+  | 'git'
+  | 'html'
+  | 'css'
+  | 'bootstrap'
+  | 'javascript'
+  | 'nodejs'
+  | 'express'
+  | 'typescript'
+  | 'react'
+  | 'chakra-ui'
+  | 'nextjs'
+  | 'firebase'
+  | 'mysql'
+  | 'python'
+  | 'linux';
+
+export type Role = 'engineer' | 'mentor' | 'mentored';

--- a/packages/entities/members.ts
+++ b/packages/entities/members.ts
@@ -1,4 +1,5 @@
 export interface Member {
+  id: string;
   name: string;
   email: string;
   role: Role;

--- a/packages/features/firebase-context.tsx
+++ b/packages/features/firebase-context.tsx
@@ -1,32 +1,22 @@
-import { initializeApp } from 'firebase/app';
-import { getAnalytics, Analytics } from 'firebase/analytics';
 import { useState } from 'react';
 
 import { ChildrenProps, useEffectOnce } from '@packages/utils/react';
 import createCtx from '@packages/utils/createCtx';
-import firebaseConfig from '@packages/config/firebase';
 
-interface FirebaseServices {
-  analytics: Analytics;
-}
+import {
+  FirebaseWebServices,
+  getFirebaseWebServices,
+} from './services/firebase';
 
 const [useFirebaseServices, FirebaseServicesProvider] =
-  createCtx<FirebaseServices>('firebase-context');
-
-function setupFirebase(): FirebaseServices {
-  // Initialize Firebase
-  const app = initializeApp(firebaseConfig);
-  const analytics = getAnalytics(app);
-
-  return { analytics };
-}
+  createCtx<FirebaseWebServices>('firebase-context');
 
 export function FirebaseProvider({ children }: ChildrenProps) {
-  const [services, setServices] = useState<FirebaseServices | null>(null);
+  const [services, setServices] = useState<FirebaseWebServices | null>(null);
 
   useEffectOnce(() => {
     // run after DOM is available (analytics depends on it)
-    setServices(setupFirebase());
+    setServices(getFirebaseWebServices());
   });
 
   return (

--- a/packages/features/services/firebase.ts
+++ b/packages/features/services/firebase.ts
@@ -1,0 +1,62 @@
+import { initializeApp } from 'firebase/app';
+import { getAnalytics, Analytics } from 'firebase/analytics';
+import { getFirestore, collection, getDocs, addDoc } from 'firebase/firestore';
+
+import firebaseConfig from '@packages/config/firebase';
+
+import type { Member } from '@packages/entities/members';
+import type { Result } from '@packages/utils/functions';
+
+const app = initializeApp(firebaseConfig);
+const db = getFirestore(app);
+
+export function getFirebaseWebServices(): FirebaseWebServices {
+  // Initialize Firebase services
+  const analytics = getAnalytics(app);
+  return { analytics };
+}
+
+export function getFirebaseApiServices(): FirebaseApiServices {
+  const memberCollection = collection(db, 'members');
+
+  async function addMembers(member: Member): Promise<Result<AddMemberResp>> {
+    try {
+      const docRef = await addDoc(memberCollection, member);
+      const resp: AddMemberResp = { id: docRef.id };
+
+      return [resp, null];
+    } catch (e) {
+      return [null, e as Error];
+    }
+  }
+
+  async function getMembers(): Promise<Result<Member[]>> {
+    try {
+      const querySnapshot = await getDocs(memberCollection);
+      const resp = querySnapshot.docs.map((doc) => doc.data() as Member);
+
+      return [resp, null];
+    } catch (error) {
+      return [null, error as Error];
+    }
+  }
+
+  return {
+    db: { getMembers, addMembers },
+  };
+}
+
+export interface FirebaseWebServices {
+  analytics: Analytics;
+}
+
+interface FirebaseApiServices {
+  db: {
+    addMembers: (member: Member) => Promise<Result<AddMemberResp>>;
+    getMembers: () => Promise<Result<Member[]>>;
+  };
+}
+
+interface AddMemberResp {
+  id: string;
+}

--- a/packages/features/services/firebase.ts
+++ b/packages/features/services/firebase.ts
@@ -14,6 +14,21 @@ import firebaseConfig from '@packages/config/firebase';
 import type { Member } from '@packages/entities/members';
 import type { Result } from '@packages/utils/functions';
 
+interface AddMemberResp {
+  id: string;
+}
+
+interface FirebaseApiServices {
+  db: {
+    addMembers: (member: Member) => Promise<Result<AddMemberResp>>;
+    getMembers: () => Promise<Result<Member[]>>;
+  };
+}
+
+export interface FirebaseWebServices {
+  analytics: Analytics;
+}
+
 const app = initializeApp(firebaseConfig);
 const db = getFirestore(app);
 
@@ -60,19 +75,4 @@ function processMemberDocumentSnapshot(
     ...doc.data(),
     id: doc.id,
   } as Member;
-}
-
-export interface FirebaseWebServices {
-  analytics: Analytics;
-}
-
-interface FirebaseApiServices {
-  db: {
-    addMembers: (member: Member) => Promise<Result<AddMemberResp>>;
-    getMembers: () => Promise<Result<Member[]>>;
-  };
-}
-
-interface AddMemberResp {
-  id: string;
 }

--- a/packages/features/services/firebase.ts
+++ b/packages/features/services/firebase.ts
@@ -1,6 +1,13 @@
 import { initializeApp } from 'firebase/app';
 import { getAnalytics, Analytics } from 'firebase/analytics';
-import { getFirestore, collection, getDocs, addDoc } from 'firebase/firestore';
+import {
+  getFirestore,
+  collection,
+  getDocs,
+  addDoc,
+  QueryDocumentSnapshot,
+  DocumentData,
+} from 'firebase/firestore';
 
 import firebaseConfig from '@packages/config/firebase';
 
@@ -33,7 +40,7 @@ export function getFirebaseApiServices(): FirebaseApiServices {
   async function getMembers(): Promise<Result<Member[]>> {
     try {
       const querySnapshot = await getDocs(memberCollection);
-      const resp = querySnapshot.docs.map((doc) => doc.data() as Member);
+      const resp = querySnapshot.docs.map(processMemberDocumentSnapshot);
 
       return [resp, null];
     } catch (error) {
@@ -44,6 +51,15 @@ export function getFirebaseApiServices(): FirebaseApiServices {
   return {
     db: { getMembers, addMembers },
   };
+}
+
+function processMemberDocumentSnapshot(
+  doc: QueryDocumentSnapshot<DocumentData>,
+) {
+  return {
+    ...doc.data(),
+    id: doc.id,
+  } as Member;
 }
 
 export interface FirebaseWebServices {

--- a/packages/utils/functions.ts
+++ b/packages/utils/functions.ts
@@ -5,3 +5,5 @@ export function makeThrowMissingImplementation(
     throw new Error(message);
   };
 }
+
+export type Result<V, E = Error> = [V, null] | [null, E];

--- a/pages/api/_middleware.ts
+++ b/pages/api/_middleware.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export function middleware(req: NextRequest) {
+  const basicAuth = req.headers.get('authorization');
+
+  if (basicAuth) {
+    const auth = basicAuth.split(' ')[1];
+    const [user, pwd] = Buffer.from(auth, 'base64').toString().split(':');
+
+    if (user === process.env.ADMIN_USER && pwd === process.env.ADMIN_PASSWD) {
+      return NextResponse.next();
+    }
+  }
+
+  return new Response('Auth required', {
+    status: 401,
+    headers: { 'WWW-Authenticate': 'Basic realm="Secure Area"' },
+  });
+}

--- a/pages/api/members.ts
+++ b/pages/api/members.ts
@@ -1,0 +1,52 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default function members(req: NextApiRequest, res: NextApiResponse) {
+  const response: TeamResponse = {
+    members: [
+      {
+        name: 'Filipe',
+        email: 'barbosasfilipe@gmail.com',
+        role: 'engineer',
+        techs: ['react', 'chakra-ui', 'nextjs', 'git'],
+      },
+      {
+        name: 'Marco',
+        email: 'ma.souza.junior@gmail.com',
+        role: 'engineer',
+        techs: ['react', 'chakra-ui', 'nextjs', 'git'],
+      },
+    ],
+  };
+
+  res.status(200).json(response);
+}
+
+export interface TeamResponse {
+  members: Member[];
+}
+
+export interface Member {
+  name: string;
+  email: string;
+  role: Role;
+  techs: Techs[];
+}
+
+type Techs =
+  | 'git'
+  | 'html'
+  | 'css'
+  | 'bootstrap'
+  | 'javascript'
+  | 'nodejs'
+  | 'express'
+  | 'typescript'
+  | 'react'
+  | 'chakra-ui'
+  | 'nextjs'
+  | 'firebase'
+  | 'mysql'
+  | 'python'
+  | 'linux';
+
+type Role = 'engineer' | 'mentor' | 'mentored';

--- a/pages/api/members.ts
+++ b/pages/api/members.ts
@@ -1,52 +1,22 @@
+import { getFirebaseApiServices } from '@packages/features/services/firebase';
+
 import type { NextApiRequest, NextApiResponse } from 'next';
 
-export default function members(req: NextApiRequest, res: NextApiResponse) {
-  const response: TeamResponse = {
-    members: [
-      {
-        name: 'Filipe',
-        email: 'barbosasfilipe@gmail.com',
-        role: 'engineer',
-        techs: ['react', 'chakra-ui', 'nextjs', 'git'],
-      },
-      {
-        name: 'Marco',
-        email: 'ma.souza.junior@gmail.com',
-        role: 'engineer',
-        techs: ['react', 'chakra-ui', 'nextjs', 'git'],
-      },
-    ],
+export default async function members(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const { db } = getFirebaseApiServices();
+
+  const handleResponse = (resp: unknown, error: Error | null) => {
+    error !== null ? res.status(403).json(error) : res.status(200).json(resp);
   };
 
-  res.status(200).json(response);
+  if (req.method === 'POST') {
+    const [resp, error] = await db.addMembers(req.body);
+    handleResponse(resp, error);
+  } else {
+    const [resp, error] = await db.getMembers();
+    handleResponse(resp, error);
+  }
 }
-
-export interface TeamResponse {
-  members: Member[];
-}
-
-export interface Member {
-  name: string;
-  email: string;
-  role: Role;
-  techs: Techs[];
-}
-
-type Techs =
-  | 'git'
-  | 'html'
-  | 'css'
-  | 'bootstrap'
-  | 'javascript'
-  | 'nodejs'
-  | 'express'
-  | 'typescript'
-  | 'react'
-  | 'chakra-ui'
-  | 'nextjs'
-  | 'firebase'
-  | 'mysql'
-  | 'python'
-  | 'linux';
-
-type Role = 'engineer' | 'mentor' | 'mentored';

--- a/pages/team.tsx
+++ b/pages/team.tsx
@@ -1,5 +1,5 @@
 import { GetStaticProps } from 'next';
-import { Heading, Flex, Text, VStack } from '@chakra-ui/react';
+import { Heading, Flex, Text } from '@chakra-ui/react';
 import { Trans } from 'react-i18next';
 
 import { useI18n } from '@packages/features/i18n-context';
@@ -14,6 +14,7 @@ interface Props {
 
 export default function Team({ members, error }: Props) {
   const { t } = useI18n('team-page');
+  console.log(members, error);
   return (
     <Section py="10rem">
       <Flex justifyContent="center">
@@ -31,6 +32,8 @@ export default function Team({ members, error }: Props) {
         </Heading>
       </Flex>
 
+      {/* TODO: add member cards here
+
       <VStack>
         {error != null
           ? error.message
@@ -39,7 +42,7 @@ export default function Team({ members, error }: Props) {
                 {m.id} {m.name} {m.role}
               </p>
             ))}
-      </VStack>
+      </VStack> */}
     </Section>
   );
 }

--- a/pages/team.tsx
+++ b/pages/team.tsx
@@ -1,10 +1,18 @@
-import { Heading, Flex, Text } from '@chakra-ui/react';
+import { GetStaticProps } from 'next';
+import { Heading, Flex, Text, VStack } from '@chakra-ui/react';
 import { Trans } from 'react-i18next';
 
 import { useI18n } from '@packages/features/i18n-context';
 import Section from '@packages/components/Section';
+import { getFirebaseApiServices } from '@packages/features/services/firebase';
+import { Member } from '@packages/entities/members';
 
-export default function Team() {
+interface Props {
+  members: Member[] | null;
+  error: Error | null;
+}
+
+export default function Team({ members, error }: Props) {
   const { t } = useI18n('team-page');
   return (
     <Section py="10rem">
@@ -22,6 +30,27 @@ export default function Team() {
           />
         </Heading>
       </Flex>
+
+      <VStack>
+        {error != null
+          ? error.message
+          : members?.map((m) => (
+              <p key={m.id}>
+                {m.id} {m.name} {m.role}
+              </p>
+            ))}
+      </VStack>
     </Section>
   );
 }
+
+export const getStaticProps: GetStaticProps<Props> = async () => {
+  const { db } = getFirebaseApiServices();
+  const [members, error] = await db.getMembers();
+
+  return {
+    revalidate: 100, // In Seconds
+    // will be passed to the page component as props
+    props: { members, error },
+  };
+};


### PR DESCRIPTION
# Descrição

This PR integrates our app with the Firestore database.

## Changes

- extract firebase service from the react context
- create member type/entity definition
- add API to list and create members
- add simple auth middleware
- use `getStaticProps` to load members and cache it

## Notes

Links:

- [Nextjs API Routes](https://nextjs.org/docs/api-routes/introduction)
- [Nextjs Middleware](https://nextjs.org/docs/middleware)
- [Data Fetch and getStaticProps](https://nextjs.org/docs/basic-features/data-fetching#runs-on-every-request-in-development)
- [Firebase Cloud Firestore](https://firebase.google.com/docs/firestore)

it closes #77 
