### PR TITLE
Fix: Typo on project mentoring description

### DIFF
--- a/packages/locale/en.yml
+++ b/packages/locale/en.yml
@@ -43,7 +43,7 @@ mentoring:
   project-mentoring.title: Project mentoring
   project-mentoring.description: >
     It is focused on developing internal or external projects. The mentee experiences teamwork,
-    pair programmings and code reviwes, all are 100% of the time simulating the developer's
+    pair programmings and code reviews, all are 100% of the time simulating the developer's
     daily life.
 
 roadmap:

--- a/packages/locale/pt.yml
+++ b/packages/locale/pt.yml
@@ -46,7 +46,7 @@ mentoring:
   project-mentoring.title: Mentoria de projetos
   project-mentoring.description: >
     É focada em desenvolver projetos internos ou externos. O mentorando vivencia trabalho
-    em equipe, pair programmings e code reviwes, todos estão 100% do tempo simulando o dia
+    em equipe, pair programmings e code reviews, todos estão 100% do tempo simulando o dia
     a dia do desenvolvedor.
 
 roadmap:


### PR DESCRIPTION
Corrige typo na descrição da seção de mentoria de projetos.