### PR TITLE
enh: add text to cta about podcodar's scholarships

### DIFF
--- a/packages/locale/en.yml
+++ b/packages/locale/en.yml
@@ -9,7 +9,7 @@ call-to-action:
   description: >-
     We are a technology and work community that teaches programming with a focus
     on training professionals. We exist to democratize knowledge and access to job
-    opportunities in the technology area
+    opportunities in the technology area. PodCodar is and will continue to be free for everyone, asking only for your dedication. Whoever wants to contribute monetarialy, can do so by donating whatever amount they feel like. All donations are converted into scholarships to help other members keep studying and keep building this community together.
   main-button: Join us!
   secondary-button: Learn more
 

--- a/packages/locale/pt.yml
+++ b/packages/locale/pt.yml
@@ -7,10 +7,7 @@ navbar:
 call-to-action:
   title: Formação profissional para o <span>mercado de tecnologia</span>
   description: >-
-    Somos uma comunidade de tecnologia e computação que ensina programação
-    com foco na formação de profissionais. Existimos para democratizar o
-    conhecimento e o acesso às oportunidades de trabalho na área de
-    tecnologia
+    Somos uma comunidade de tecnologia e computação que ensina programação com foco na formação de profissionais. Existimos para democratizar o conhecimento e o acesso às oportunidades de trabalho na área de tecnologia. A PodCodar é e vai continuar sendo grátis para todos, cobrando somente a sua dedicação. Quem quiser contribuir monetariamente também pode doar a quantia que quiser. Todas as doações são convertidas em bolsas de estudo para ajudar outros membros a continuarem estudando e construindo juntos esta comunidade.
   main-button: Faça parte!
   secondary-button: Saiba mais
 


### PR DESCRIPTION
# Description

> Added some simple text in portuguese/english on the the call-to-action's description about donations and scholarships. Most importantly was to say that the community is free, so anyone who randomly stumbles on it don't mistake it for a paid service or at least know that PodCodar won't charge people to participate.

## Notes

> Was in doubt if I should write this PR in english or portuguese since it has been some time but checking other recent PRs it seems that english is the current pattern but please let me know otherwise.

Updated text in pt-br:
![image](https://user-images.githubusercontent.com/28074722/168203751-b5d4fc79-6da7-46e1-8091-804dcef640ce.png)

Updated text in english:
![image](https://user-images.githubusercontent.com/28074722/168203800-23bfb350-8529-42e2-9760-c44a54f914cf.png)
