### PR TITLE
feat:  create add-testimonial page

### DIFF
--- a/packages/components/AddTestimonialForm.tsx
+++ b/packages/components/AddTestimonialForm.tsx
@@ -1,0 +1,3 @@
+export default function AddTestimonialForm() {
+  return <div>AddTestimonialForm</div>;
+}

--- a/packages/components/AddTestimonialForm.tsx
+++ b/packages/components/AddTestimonialForm.tsx
@@ -1,3 +1,0 @@
-export default function AddTestimonialForm() {
-  return <div>AddTestimonialForm</div>;
-}

--- a/packages/entities/testimonials.ts
+++ b/packages/entities/testimonials.ts
@@ -4,4 +4,5 @@ export interface Testimonial {
   profileUrl: string;
   avatarUrl: string;
   text: string;
+  approved: boolean;
 }

--- a/packages/hooks/useCustomToast.tsx
+++ b/packages/hooks/useCustomToast.tsx
@@ -1,31 +1,24 @@
 import { useToast } from '@chakra-ui/react';
 
-import { useI18n } from '@packages/features/i18n-context';
+import { TranslationNS, useI18n } from '@packages/features/i18n-context';
 
-export default function useCustomToast() {
-  const { t } = useI18n('testimonials');
+export default function useCustomToast(source: string) {
+  const { t } = useI18n(source as TranslationNS);
   const toast = useToast();
 
-  const errorToast = () =>
+  const errorToast = (key: string) =>
     toast({
-      description: t('toast.inputError'),
+      description: t(key),
       status: 'error',
       isClosable: true,
     });
 
-  const invalidUserToast = () =>
+  const successToast = (key: string) =>
     toast({
-      description: t('toast.invalidUserError'),
-      status: 'error',
-      isClosable: true,
-    });
-
-  const successToast = () =>
-    toast({
-      description: t('toast.success'),
+      description: t(key),
       status: 'success',
       isClosable: true,
     });
 
-  return { errorToast, invalidUserToast, successToast };
+  return { errorToast, successToast };
 }

--- a/packages/hooks/useCustomToast.tsx
+++ b/packages/hooks/useCustomToast.tsx
@@ -1,0 +1,31 @@
+import { useToast } from '@chakra-ui/react';
+
+import { useI18n } from '@packages/features/i18n-context';
+
+export default function useCustomToast() {
+  const { t } = useI18n('testimonials');
+  const toast = useToast();
+
+  const errorToast = () =>
+    toast({
+      description: t('toast.inputError'),
+      status: 'error',
+      isClosable: true,
+    });
+
+  const invalidUserToast = () =>
+    toast({
+      description: t('toast.invalidUserError'),
+      status: 'error',
+      isClosable: true,
+    });
+
+  const successToast = () =>
+    toast({
+      description: t('toast.success'),
+      status: 'success',
+      isClosable: true,
+    });
+
+  return { errorToast, invalidUserToast, successToast };
+}

--- a/packages/locale/en.yml
+++ b/packages/locale/en.yml
@@ -48,8 +48,10 @@ testimonials:
   label.name: Name
   label.github: Github username
   label.testimonial: Testimonial
+  label.error: '{{label}} must be between {{min}} and {{max}} characters'
   toast.inputError: Please fill the form
   toast.invalidUserError: Invalid github user
+  toast.serverError: Internal Server Error
   toast.success: Success
   submit: Submit
 

--- a/packages/locale/en.yml
+++ b/packages/locale/en.yml
@@ -44,6 +44,11 @@ mentoring:
 
 testimonials:
   title: Testimonials
+  add-testimonial-title: Add Testimonial
+  label.name: Name
+  label.github: Github username
+  label.testimonial: Testimonial
+  submit: Submit
 
 roadmap:
   title: Check our roadmaps

--- a/packages/locale/en.yml
+++ b/packages/locale/en.yml
@@ -48,6 +48,9 @@ testimonials:
   label.name: Name
   label.github: Github username
   label.testimonial: Testimonial
+  toast.inputError: Please fill the form
+  toast.invalidUserError: Invalid github user
+  toast.success: Success
   submit: Submit
 
 roadmap:

--- a/packages/locale/pt.yml
+++ b/packages/locale/pt.yml
@@ -61,8 +61,10 @@ testimonials:
   label.name: Nome
   label.github: Usuário do Github
   label.testimonial: Testemunho
+  label.error: '{{label}} deve ter entre {{min}} e {{max}} caracteres'
   toast.inputError: Por favor preencha os campos
   toast.invalidUserError: Usuário do github invalido
+  toast.serverError: Erro de Servidor
   toast.success: Sucesso
   submit: Enviar
 

--- a/packages/locale/pt.yml
+++ b/packages/locale/pt.yml
@@ -61,6 +61,9 @@ testimonials:
   label.name: Nome
   label.github: Usuário do Github
   label.testimonial: Testemunho
+  toast.inputError: Por favor preencha os campos
+  toast.invalidUserError: Usuário do github invalido
+  toast.success: Sucesso
   submit: Enviar
 
 footer:

--- a/packages/locale/pt.yml
+++ b/packages/locale/pt.yml
@@ -57,6 +57,11 @@ roadmap:
 
 testimonials:
   title: Testemunhos
+  add-testimonial-title: Adicione um Testemunho
+  label.name: Nome
+  label.github: Usuário do Github
+  label.testimonial: Testemunho
+  submit: Enviar
 
 footer:
   contribution: Contribua Conosco

--- a/packages/services/testimonials.ts
+++ b/packages/services/testimonials.ts
@@ -6,6 +6,12 @@ import {
 } from '@packages/repositories/firestore';
 import { Testimonial } from '@packages/entities/testimonials';
 
+interface testimonialProps {
+  name: string;
+  testimonial: string;
+  gitUsername: string;
+}
+
 let testimonials: undefined | FirestoreDAO<Testimonial>;
 export function getTestimonialInstance() {
   if (testimonials != null) return testimonials;
@@ -22,4 +28,28 @@ function processQuestionSnapshot(doc: QueryDocumentSnapshot<DocumentData>) {
     ...doc.data(),
     id: doc.id,
   } as Testimonial;
+}
+
+export async function addTestimonial({
+  name,
+  testimonial,
+  gitUsername,
+}: testimonialProps) {
+  const testimonialsService = getTestimonialInstance();
+  try {
+    const member = await fetch(
+      `https://api.github.com/users/${gitUsername}`,
+    ).then((r) => r.json());
+
+    await testimonialsService.add({
+      name: name,
+      text: testimonial,
+      profileUrl: member.html_url,
+      avatarUrl: member.avatar_url,
+      approved: false,
+    });
+  } catch (e) {
+    return 1;
+  }
+  return 0;
 }

--- a/packages/services/testimonials.ts
+++ b/packages/services/testimonials.ts
@@ -54,5 +54,5 @@ export async function addTestimonial({
   } catch (e) {
     return 'toast.serverError';
   }
-  return 0;
+  return;
 }

--- a/packages/services/testimonials.ts
+++ b/packages/services/testimonials.ts
@@ -41,7 +41,7 @@ export async function addTestimonial({
   ).then((r) => r.json());
 
   if (member.message === 'Not Found') {
-    return 1;
+    return 'toast.invalidUserError';
   }
   try {
     await testimonialsService.add({
@@ -52,7 +52,7 @@ export async function addTestimonial({
       approved: false,
     });
   } catch (e) {
-    return 2;
+    return 'toast.serverError';
   }
   return 0;
 }

--- a/packages/services/testimonials.ts
+++ b/packages/services/testimonials.ts
@@ -49,7 +49,7 @@ export async function addTestimonial({
       approved: false,
     });
   } catch (e) {
-    return 1;
+    return e;
   }
   return 0;
 }

--- a/packages/services/testimonials.ts
+++ b/packages/services/testimonials.ts
@@ -36,11 +36,14 @@ export async function addTestimonial({
   gitUsername,
 }: testimonialProps) {
   const testimonialsService = getTestimonialInstance();
-  try {
-    const member = await fetch(
-      `https://api.github.com/users/${gitUsername}`,
-    ).then((r) => r.json());
+  const member = await fetch(
+    `https://api.github.com/users/${gitUsername}`,
+  ).then((r) => r.json());
 
+  if (member.message === 'Not Found') {
+    return 1;
+  }
+  try {
     await testimonialsService.add({
       name: name,
       text: testimonial,
@@ -49,7 +52,7 @@ export async function addTestimonial({
       approved: false,
     });
   } catch (e) {
-    return e;
+    return 2;
   }
   return 0;
 }

--- a/pages/app/add-testimonial.tsx
+++ b/pages/app/add-testimonial.tsx
@@ -24,6 +24,9 @@ export default function AddTestimonialPage() {
 
   function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
+    if (testimonial.length < 10 || testimonial.length > 300) {
+      return;
+    }
     addTestimonial({
       name,
       testimonial,

--- a/pages/app/add-testimonial.tsx
+++ b/pages/app/add-testimonial.tsx
@@ -22,16 +22,29 @@ export default function AddTestimonialPage() {
   const [name, setName] = useState<string>('');
   const [gitUsername, setGitUsername] = useState('');
 
+  function validateInput(e: string) {
+    if (e.length > 300) {
+      alert('Desculpe mas esse campo é limitado a 300 caracteres');
+      return false;
+    } else return true;
+  }
+
+  function validateSubmit() {
+    if (name.length < 5 || testimonial.length < 20) {
+      alert('Por favor preencha os campos');
+      return false;
+    } else return true;
+  }
+
   function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    if (testimonial.length < 10 || testimonial.length > 300) {
-      return;
+    if (validateSubmit()) {
+      addTestimonial({
+        name,
+        testimonial,
+        gitUsername,
+      });
     }
-    addTestimonial({
-      name,
-      testimonial,
-      gitUsername,
-    });
   }
 
   async function addTestimonial({
@@ -53,7 +66,8 @@ export default function AddTestimonialPage() {
         avatarUrl: member.avatar_url,
       });
     } catch (e) {
-      alert(`invalid input ${e}`);
+      alert(`invalid github user`);
+      return;
     }
 
     setTestimonial('');
@@ -70,7 +84,7 @@ export default function AddTestimonialPage() {
           <Input
             type="text"
             onChange={(e: ChangeEvent<HTMLInputElement>) =>
-              setName(e.target.value)
+              validateInput(e.target.value) && setName(e.target.value)
             }
             value={name}
           />
@@ -79,7 +93,7 @@ export default function AddTestimonialPage() {
         <Input
           type="text"
           onChange={(e: ChangeEvent<HTMLInputElement>) =>
-            setGitUsername(e.target.value)
+            validateInput(e.target.value) && setGitUsername(e.target.value)
           }
           value={gitUsername}
         />
@@ -87,7 +101,7 @@ export default function AddTestimonialPage() {
           <FormLabel>Testimonial</FormLabel>
           <Textarea
             onChange={(e: ChangeEvent<HTMLTextAreaElement>) =>
-              setTestimonial(e.target.value)
+              validateInput(e.target.value) && setTestimonial(e.target.value)
             }
             value={testimonial}
           />

--- a/pages/app/add-testimonial.tsx
+++ b/pages/app/add-testimonial.tsx
@@ -62,8 +62,7 @@ export default function AddTestimonialPage() {
     });
     setIsLoading(false);
 
-    if (error === 1) return errorToast('toast.invalidUserError');
-    if (error === 2) return errorToast('toast.serverError');
+    if (error) return errorToast(error);
 
     successToast('toast.success');
     clearForm();

--- a/pages/app/add-testimonial.tsx
+++ b/pages/app/add-testimonial.tsx
@@ -1,0 +1,5 @@
+import Section from '@packages/components/Section';
+
+export default function addTestimonialPage() {
+  return <Section py="5rem">add-testimonial</Section>;
+}

--- a/pages/app/add-testimonial.tsx
+++ b/pages/app/add-testimonial.tsx
@@ -31,7 +31,7 @@ export default function AddTestimonialPage() {
   function validateSubmit() {
     if (name.length < 5 || testimonial.length < 20) {
       toast({
-        description: 'Por favor preencha os campos',
+        description: t('toast.inputError'),
         status: 'error',
         isClosable: true,
       });
@@ -72,7 +72,7 @@ export default function AddTestimonialPage() {
       });
     } catch (e) {
       toast({
-        description: `invalid github user`,
+        description: t('toast.invalidUserError'),
         status: 'error',
         isClosable: true,
       });
@@ -81,7 +81,11 @@ export default function AddTestimonialPage() {
     }
 
     setIsLoading(false);
-    toast({ description: 'success', status: 'success', isClosable: true });
+    toast({
+      description: t('toast.success'),
+      status: 'success',
+      isClosable: true,
+    });
     setTestimonial('');
     setName('');
     setGitUsername('');

--- a/pages/app/add-testimonial.tsx
+++ b/pages/app/add-testimonial.tsx
@@ -61,8 +61,8 @@ export default function AddTestimonialPage() {
     <Section py="5rem">
       <Heading py="1rem">{t('add-testimonial-title')}</Heading>
       <form onSubmit={handleSubmit}>
-        <FormControl isInvalid={isNameInvalid}>
-          <FormLabel>{t('label.name')}</FormLabel>
+        <FormControl isInvalid={isNameInvalid} pt="1rem">
+          <FormLabel pb="0.5rem">{t('label.name')}</FormLabel>
           <Input
             name="name"
             type="text"
@@ -71,16 +71,18 @@ export default function AddTestimonialPage() {
             value={name}
           />
         </FormControl>
-        <FormLabel>{t('label.github')}</FormLabel>
-        <Input
-          name="gitUsername"
-          type="text"
-          maxLength={maxInputLength}
-          onChange={onChange}
-          value={gitUsername}
-        />
-        <FormControl isInvalid={isTestimonialInvalid}>
-          <FormLabel>{t('label.testimonial')}</FormLabel>
+        <FormControl pt="2rem">
+          <FormLabel pb="0.5rem">{t('label.github')}</FormLabel>
+          <Input
+            name="gitUsername"
+            type="text"
+            maxLength={maxInputLength}
+            onChange={onChange}
+            value={gitUsername}
+          />
+        </FormControl>
+        <FormControl isInvalid={isTestimonialInvalid} py="2rem">
+          <FormLabel pb="0.5rem">{t('label.testimonial')}</FormLabel>
           <Textarea
             name="testimonial"
             maxLength={maxInputLength}
@@ -89,7 +91,7 @@ export default function AddTestimonialPage() {
           />
         </FormControl>
 
-        <Button mt="1rem" type="submit" isLoading={isLoading}>
+        <Button type="submit" isLoading={isLoading}>
           {t('submit')}
         </Button>
       </form>

--- a/pages/app/add-testimonial.tsx
+++ b/pages/app/add-testimonial.tsx
@@ -11,6 +11,7 @@ import { ChangeEvent, FormEvent, useState } from 'react';
 
 import Section from '@packages/components/Section';
 import { getTestimonialInstance } from '@packages/services/testimonials';
+import { useI18n } from '@packages/features/i18n-context';
 
 interface testimonialProps {
   name: string;
@@ -19,6 +20,7 @@ interface testimonialProps {
 }
 
 export default function AddTestimonialPage() {
+  const { t } = useI18n('testimonials');
   const [testimonial, setTestimonial] = useState<string>('');
   const [name, setName] = useState<string>('');
   const [gitUsername, setGitUsername] = useState('');
@@ -83,10 +85,10 @@ export default function AddTestimonialPage() {
 
   return (
     <Section py="5rem">
-      <Heading>Add Testimonial</Heading>
+      <Heading>{t('add-testimonial-title')}</Heading>
       <form onSubmit={handleSubmit}>
         <FormControl>
-          <FormLabel>Name</FormLabel>
+          <FormLabel>{t('label.name')}</FormLabel>
           <Input
             type="text"
             maxLength={maxInputLength}
@@ -96,7 +98,7 @@ export default function AddTestimonialPage() {
             value={name}
           />
         </FormControl>
-        <FormLabel>Github username</FormLabel>
+        <FormLabel>{t('label.github')}</FormLabel>
         <Input
           type="text"
           maxLength={maxInputLength}
@@ -106,7 +108,7 @@ export default function AddTestimonialPage() {
           value={gitUsername}
         />
         <FormControl>
-          <FormLabel>Testimonial</FormLabel>
+          <FormLabel>{t('label.testimonial')}</FormLabel>
           <Textarea
             maxLength={maxInputLength}
             onChange={(e: ChangeEvent<HTMLTextAreaElement>) =>
@@ -117,7 +119,7 @@ export default function AddTestimonialPage() {
         </FormControl>
 
         <Button mt="1rem" type="submit">
-          Submit
+          {t('submit')}
         </Button>
       </form>
     </Section>

--- a/pages/app/add-testimonial.tsx
+++ b/pages/app/add-testimonial.tsx
@@ -35,9 +35,11 @@ export default function AddTestimonialPage() {
     setFormState({ name: '', gitUsername: '', testimonial: '' });
   }
 
+  const isNameInvalid = name.length < 5;
+  const isTestimonialInvalid = testimonial.length < 20;
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    const isSubmitInvalid = name.length < 5 || testimonial.length < 20;
+    const isSubmitInvalid = isNameInvalid || isTestimonialInvalid;
 
     if (isSubmitInvalid) return errorToast();
 
@@ -59,7 +61,7 @@ export default function AddTestimonialPage() {
     <Section py="5rem">
       <Heading py="1rem">{t('add-testimonial-title')}</Heading>
       <form onSubmit={handleSubmit}>
-        <FormControl>
+        <FormControl isInvalid={isNameInvalid}>
           <FormLabel>{t('label.name')}</FormLabel>
           <Input
             name="name"
@@ -77,7 +79,7 @@ export default function AddTestimonialPage() {
           onChange={onChange}
           value={gitUsername}
         />
-        <FormControl>
+        <FormControl isInvalid={isTestimonialInvalid}>
           <FormLabel>{t('label.testimonial')}</FormLabel>
           <Textarea
             name="testimonial"

--- a/pages/app/add-testimonial.tsx
+++ b/pages/app/add-testimonial.tsx
@@ -100,7 +100,11 @@ export default function AddTestimonialPage() {
           />
           {name.error && (
             <FormErrorMessage>
-              name must be between 5 and 40 characters
+              {t('label.error', {
+                label: t('label.name'),
+                min: '5',
+                max: '40',
+              })}
             </FormErrorMessage>
           )}
         </FormControl>
@@ -115,7 +119,11 @@ export default function AddTestimonialPage() {
           />
           {gitUsername.error && (
             <FormErrorMessage>
-              username must be between 4 and 20 characters
+              {t('label.error', {
+                label: t('label.github'),
+                min: '4',
+                max: '20',
+              })}
             </FormErrorMessage>
           )}
         </FormControl>
@@ -129,7 +137,11 @@ export default function AddTestimonialPage() {
           />
           {name.error && (
             <FormErrorMessage>
-              testimonial must be between 20 and 300 characters
+              {t('label.error', {
+                label: t('label.testimonial'),
+                min: '20',
+                max: '300',
+              })}
             </FormErrorMessage>
           )}
         </FormControl>

--- a/pages/app/add-testimonial.tsx
+++ b/pages/app/add-testimonial.tsx
@@ -64,6 +64,7 @@ export default function AddTestimonialPage() {
         text: testimonial,
         profileUrl: member.html_url,
         avatarUrl: member.avatar_url,
+        approved: false,
       });
     } catch (e) {
       alert(`invalid github user`);

--- a/pages/app/add-testimonial.tsx
+++ b/pages/app/add-testimonial.tsx
@@ -5,6 +5,7 @@ import {
   Heading,
   FormControl,
   FormLabel,
+  useToast,
 } from '@chakra-ui/react';
 import { ChangeEvent, FormEvent, useState } from 'react';
 
@@ -21,17 +22,16 @@ export default function AddTestimonialPage() {
   const [testimonial, setTestimonial] = useState<string>('');
   const [name, setName] = useState<string>('');
   const [gitUsername, setGitUsername] = useState('');
-
-  function validateInput(e: string) {
-    if (e.length > 300) {
-      alert('Desculpe mas esse campo é limitado a 300 caracteres');
-      return false;
-    } else return true;
-  }
+  const maxInputLength: number = 300;
+  const toast = useToast();
 
   function validateSubmit() {
     if (name.length < 5 || testimonial.length < 20) {
-      alert('Por favor preencha os campos');
+      toast({
+        description: 'Por favor preencha os campos',
+        status: 'error',
+        isClosable: true,
+      });
       return false;
     } else return true;
   }
@@ -67,10 +67,15 @@ export default function AddTestimonialPage() {
         approved: false,
       });
     } catch (e) {
-      alert(`invalid github user`);
+      toast({
+        description: `invalid github user`,
+        status: 'error',
+        isClosable: true,
+      });
       return;
     }
 
+    toast({ description: 'success', status: 'success', isClosable: true });
     setTestimonial('');
     setName('');
     setGitUsername('');
@@ -84,8 +89,9 @@ export default function AddTestimonialPage() {
           <FormLabel>Name</FormLabel>
           <Input
             type="text"
+            maxLength={maxInputLength}
             onChange={(e: ChangeEvent<HTMLInputElement>) =>
-              validateInput(e.target.value) && setName(e.target.value)
+              setName(e.target.value)
             }
             value={name}
           />
@@ -93,16 +99,18 @@ export default function AddTestimonialPage() {
         <FormLabel>Github username</FormLabel>
         <Input
           type="text"
+          maxLength={maxInputLength}
           onChange={(e: ChangeEvent<HTMLInputElement>) =>
-            validateInput(e.target.value) && setGitUsername(e.target.value)
+            setGitUsername(e.target.value)
           }
           value={gitUsername}
         />
         <FormControl>
           <FormLabel>Testimonial</FormLabel>
           <Textarea
+            maxLength={maxInputLength}
             onChange={(e: ChangeEvent<HTMLTextAreaElement>) =>
-              validateInput(e.target.value) && setTestimonial(e.target.value)
+              setTestimonial(e.target.value)
             }
             value={testimonial}
           />

--- a/pages/app/add-testimonial.tsx
+++ b/pages/app/add-testimonial.tsx
@@ -37,7 +37,7 @@ export default function AddTestimonialPage() {
   ) {
     setFormState({
       ...formState,
-      [event.target.name]: { ...event.target, name: event.target.value },
+      [event.target.name]: { value: event.target.value, error: false },
     });
   }
 

--- a/pages/app/add-testimonial.tsx
+++ b/pages/app/add-testimonial.tsx
@@ -5,6 +5,7 @@ import {
   Heading,
   FormControl,
   FormLabel,
+  FormErrorMessage,
 } from '@chakra-ui/react';
 import { ChangeEvent, FormEvent, useState } from 'react';
 
@@ -13,14 +14,20 @@ import { useI18n } from '@packages/features/i18n-context';
 import { addTestimonial } from '@packages/services/testimonials';
 import useCustomToast from '@packages/hooks/useCustomToast';
 
+interface formState {
+  name: { value: string; error: boolean };
+  gitUsername: { value: string; error: boolean };
+  testimonial: { value: string; error: boolean };
+}
+
 export default function AddTestimonialPage() {
-  const { errorToast, invalidUserToast, successToast } = useCustomToast();
+  const { errorToast, successToast } = useCustomToast('testimonials');
   const { t } = useI18n('testimonials');
   const [isLoading, setIsLoading] = useState(false);
-  const [formState, setFormState] = useState({
-    name: '',
-    gitUsername: '',
-    testimonial: '',
+  const [formState, setFormState] = useState<formState>({
+    name: { value: '', error: false },
+    gitUsername: { value: '', error: false },
+    testimonial: { value: '', error: false },
   });
   const { name, gitUsername, testimonial } = formState;
   const maxInputLength: number = 300;
@@ -28,67 +35,102 @@ export default function AddTestimonialPage() {
   function onChange(
     event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
   ) {
-    setFormState({ ...formState, [event.target.name]: event.target.value });
+    setFormState({
+      ...formState,
+      [event.target.name]: { ...event.target, name: event.target.value },
+    });
   }
 
   function clearForm() {
-    setFormState({ name: '', gitUsername: '', testimonial: '' });
+    setFormState({
+      name: { value: '', error: false },
+      gitUsername: { value: '', error: false },
+      testimonial: { value: '', error: false },
+    });
   }
 
-  const isNameInvalid = name.length < 5;
-  const isTestimonialInvalid = testimonial.length < 20;
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    const isSubmitInvalid = isNameInvalid || isTestimonialInvalid;
 
-    if (isSubmitInvalid) return errorToast();
+    if (checkInvalidInputs()) return errorToast('toast.inputError');
 
     setIsLoading(true);
     const error = await addTestimonial({
-      name,
-      testimonial,
-      gitUsername,
+      name: name.value,
+      testimonial: testimonial.value,
+      gitUsername: gitUsername.value,
     });
     setIsLoading(false);
 
-    if (error) return invalidUserToast();
+    if (error) return errorToast('toast.invalidUserError');
 
-    successToast();
+    successToast('toast.success');
     clearForm();
+  }
+
+  function checkInvalidInputs() {
+    const nameInvalid = name.value.length < 5 || name.value.length > 40;
+    const gituserInvalid = gitUsername.value.length < 4;
+    const testimonialInvalid =
+      testimonial.value.length < 20 || testimonial.value.length > 300;
+
+    setFormState({
+      ...formState,
+      name: { ...name, error: nameInvalid },
+      gitUsername: { ...gitUsername, error: gituserInvalid },
+      testimonial: { ...testimonial, error: testimonialInvalid },
+    });
+
+    return [nameInvalid, gituserInvalid, testimonialInvalid].includes(true);
   }
 
   return (
     <Section py="5rem">
       <Heading py="1rem">{t('add-testimonial-title')}</Heading>
       <form onSubmit={handleSubmit}>
-        <FormControl isInvalid={isNameInvalid} pt="1rem">
+        <FormControl isInvalid={name.error} pt="1rem">
           <FormLabel pb="0.5rem">{t('label.name')}</FormLabel>
           <Input
             name="name"
             type="text"
             maxLength={maxInputLength}
             onChange={onChange}
-            value={name}
+            value={name.value}
           />
+          {name.error && (
+            <FormErrorMessage>
+              name must be between 5 and 40 characters
+            </FormErrorMessage>
+          )}
         </FormControl>
-        <FormControl pt="2rem">
+        <FormControl pt="2rem" isInvalid={gitUsername.error}>
           <FormLabel pb="0.5rem">{t('label.github')}</FormLabel>
           <Input
             name="gitUsername"
             type="text"
             maxLength={maxInputLength}
             onChange={onChange}
-            value={gitUsername}
+            value={gitUsername.value}
           />
+          {gitUsername.error && (
+            <FormErrorMessage>
+              username must be between 4 and 20 characters
+            </FormErrorMessage>
+          )}
         </FormControl>
-        <FormControl isInvalid={isTestimonialInvalid} py="2rem">
+        <FormControl isInvalid={testimonial.error} py="2rem">
           <FormLabel pb="0.5rem">{t('label.testimonial')}</FormLabel>
           <Textarea
             name="testimonial"
             maxLength={maxInputLength}
             onChange={onChange}
-            value={testimonial}
+            value={testimonial.value}
           />
+          {name.error && (
+            <FormErrorMessage>
+              testimonial must be between 20 and 300 characters
+            </FormErrorMessage>
+          )}
         </FormControl>
 
         <Button type="submit" isLoading={isLoading}>

--- a/pages/app/add-testimonial.tsx
+++ b/pages/app/add-testimonial.tsx
@@ -62,7 +62,8 @@ export default function AddTestimonialPage() {
     });
     setIsLoading(false);
 
-    if (error) return errorToast('toast.invalidUserError');
+    if (error === 1) return errorToast('toast.invalidUserError');
+    if (error === 2) return errorToast('toast.serverError');
 
     successToast('toast.success');
     clearForm();

--- a/pages/app/add-testimonial.tsx
+++ b/pages/app/add-testimonial.tsx
@@ -9,13 +9,53 @@ import {
 import { ChangeEvent, FormEvent, useState } from 'react';
 
 import Section from '@packages/components/Section';
+import { getTestimonialInstance } from '@packages/services/testimonials';
+
+interface testimonialProps {
+  name: string;
+  testimonial: string;
+  gitUsername: string;
+}
 
 export default function AddTestimonialPage() {
   const [testimonial, setTestimonial] = useState<string>('');
   const [name, setName] = useState<string>('');
+  const [gitUsername, setGitUsername] = useState('');
 
   function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
+    addTestimonial({
+      name,
+      testimonial,
+      gitUsername,
+    });
+  }
+
+  async function addTestimonial({
+    name,
+    testimonial,
+    gitUsername,
+  }: testimonialProps) {
+    const testimonialsService = getTestimonialInstance();
+
+    const member = await fetch(
+      `https://api.github.com/users/${gitUsername}`,
+    ).then((r) => r.json());
+
+    try {
+      await testimonialsService.add({
+        name: name,
+        text: testimonial,
+        profileUrl: member.html_url,
+        avatarUrl: member.avatar_url,
+      });
+    } catch (e) {
+      alert(`invalid input ${e}`);
+    }
+
+    setTestimonial('');
+    setName('');
+    setGitUsername('');
   }
 
   return (
@@ -32,6 +72,14 @@ export default function AddTestimonialPage() {
             value={name}
           />
         </FormControl>
+        <FormLabel>Github username</FormLabel>
+        <Input
+          type="text"
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+            setGitUsername(e.target.value)
+          }
+          value={gitUsername}
+        />
         <FormControl>
           <FormLabel>Testimonial</FormLabel>
           <Textarea
@@ -41,6 +89,7 @@ export default function AddTestimonialPage() {
             value={testimonial}
           />
         </FormControl>
+
         <Button mt="1rem" type="submit">
           Submit
         </Button>

--- a/pages/app/add-testimonial.tsx
+++ b/pages/app/add-testimonial.tsx
@@ -1,5 +1,50 @@
+import {
+  Input,
+  Textarea,
+  Button,
+  Heading,
+  FormControl,
+  FormLabel,
+} from '@chakra-ui/react';
+import { ChangeEvent, FormEvent, useState } from 'react';
+
 import Section from '@packages/components/Section';
 
-export default function addTestimonialPage() {
-  return <Section py="5rem">add-testimonial</Section>;
+export default function AddTestimonialPage() {
+  const [testimonial, setTestimonial] = useState<string>('');
+  const [name, setName] = useState<string>('');
+
+  function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+  }
+
+  return (
+    <Section py="5rem">
+      <Heading>Add Testimonial</Heading>
+      <form onSubmit={handleSubmit}>
+        <FormControl>
+          <FormLabel>Name</FormLabel>
+          <Input
+            type="text"
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              setName(e.target.value)
+            }
+            value={name}
+          />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Testimonial</FormLabel>
+          <Textarea
+            onChange={(e: ChangeEvent<HTMLTextAreaElement>) =>
+              setTestimonial(e.target.value)
+            }
+            value={testimonial}
+          />
+        </FormControl>
+        <Button mt="1rem" type="submit">
+          Submit
+        </Button>
+      </form>
+    </Section>
+  );
 }

--- a/pages/app/add-testimonial.tsx
+++ b/pages/app/add-testimonial.tsx
@@ -29,14 +29,13 @@ export default function AddTestimonialPage() {
   const toast = useToast();
 
   function validateSubmit() {
-    if (name.length < 5 || testimonial.length < 20) {
-      toast({
-        description: t('toast.inputError'),
-        status: 'error',
-        isClosable: true,
-      });
-      return false;
-    } else return true;
+    if (!(name.length < 5) || !(testimonial.length < 20)) return true;
+
+    toast({
+      description: t('toast.inputError'),
+      status: 'error',
+      isClosable: true,
+    });
   }
 
   function handleSubmit(e: FormEvent<HTMLFormElement>) {

--- a/pages/app/add-testimonial.tsx
+++ b/pages/app/add-testimonial.tsx
@@ -93,7 +93,7 @@ export default function AddTestimonialPage() {
 
   return (
     <Section py="5rem">
-      <Heading>{t('add-testimonial-title')}</Heading>
+      <Heading py="1rem">{t('add-testimonial-title')}</Heading>
       <form onSubmit={handleSubmit}>
         <FormControl>
           <FormLabel>{t('label.name')}</FormLabel>

--- a/pages/app/add-testimonial.tsx
+++ b/pages/app/add-testimonial.tsx
@@ -5,15 +5,16 @@ import {
   Heading,
   FormControl,
   FormLabel,
-  useToast,
 } from '@chakra-ui/react';
 import { ChangeEvent, FormEvent, useState } from 'react';
 
 import Section from '@packages/components/Section';
 import { useI18n } from '@packages/features/i18n-context';
 import { addTestimonial } from '@packages/services/testimonials';
+import useCustomToast from '@packages/hooks/useCustomToast';
 
 export default function AddTestimonialPage() {
+  const { errorToast, invalidUserToast, successToast } = useCustomToast();
   const { t } = useI18n('testimonials');
   const [isLoading, setIsLoading] = useState(false);
   const [formState, setFormState] = useState({
@@ -23,7 +24,6 @@ export default function AddTestimonialPage() {
   });
   const { name, gitUsername, testimonial } = formState;
   const maxInputLength: number = 300;
-  const toast = useToast();
 
   function onChange(
     event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
@@ -39,36 +39,20 @@ export default function AddTestimonialPage() {
     e.preventDefault();
     const isSubmitInvalid = name.length < 5 || testimonial.length < 20;
 
-    if (isSubmitInvalid)
-      toast({
-        description: t('toast.inputError'),
-        status: 'error',
-        isClosable: true,
-      });
-    else {
-      setIsLoading(true);
-      const error = await addTestimonial({
-        name,
-        testimonial,
-        gitUsername,
-      });
-      setIsLoading(false);
+    if (isSubmitInvalid) return errorToast();
 
-      if (error) {
-        toast({
-          description: t('toast.invalidUserError'),
-          status: 'error',
-          isClosable: true,
-        });
-      } else {
-        toast({
-          description: t('toast.success'),
-          status: 'success',
-          isClosable: true,
-        });
-        clearForm();
-      }
-    }
+    setIsLoading(true);
+    const error = await addTestimonial({
+      name,
+      testimonial,
+      gitUsername,
+    });
+    setIsLoading(false);
+
+    if (error) return invalidUserToast();
+
+    successToast();
+    clearForm();
   }
 
   return (

--- a/pages/app/add-testimonial.tsx
+++ b/pages/app/add-testimonial.tsx
@@ -24,6 +24,7 @@ export default function AddTestimonialPage() {
   const [testimonial, setTestimonial] = useState<string>('');
   const [name, setName] = useState<string>('');
   const [gitUsername, setGitUsername] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
   const maxInputLength: number = 300;
   const toast = useToast();
 
@@ -54,6 +55,7 @@ export default function AddTestimonialPage() {
     testimonial,
     gitUsername,
   }: testimonialProps) {
+    setIsLoading(true);
     const testimonialsService = getTestimonialInstance();
 
     const member = await fetch(
@@ -74,9 +76,11 @@ export default function AddTestimonialPage() {
         status: 'error',
         isClosable: true,
       });
+      setIsLoading(false);
       return;
     }
 
+    setIsLoading(false);
     toast({ description: 'success', status: 'success', isClosable: true });
     setTestimonial('');
     setName('');
@@ -118,7 +122,7 @@ export default function AddTestimonialPage() {
           />
         </FormControl>
 
-        <Button mt="1rem" type="submit">
+        <Button mt="1rem" type="submit" isLoading={isLoading}>
           {t('submit')}
         </Button>
       </form>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -36,7 +36,9 @@ export const getStaticProps: GetStaticProps<Props> = async () => {
   let error: Error | null = null;
 
   try {
-    testimonials = await testimonialsService.list();
+    testimonials = await (
+      await testimonialsService.list()
+    ).filter((t) => t.approved === true);
   } catch (e) {
     error = e as Error;
   }


### PR DESCRIPTION
# Descrição

creates and adds testimonial page
store testimonial on database
validate testimonial before storing
I18n texts

## Notes

> page path `/app/add-testimonial`

closes #136