### PR TITLE
fix: turn static props serializable

### DIFF
--- a/pages/team.tsx
+++ b/pages/team.tsx
@@ -13,7 +13,7 @@ import useEditingMode from '@packages/hooks/useEditingMode';
 
 interface Props {
   members: Member[] | null;
-  error: Error | null;
+  error: string | undefined;
 }
 
 export default function Team({ members, error }: Props) {
@@ -49,8 +49,8 @@ export default function Team({ members, error }: Props) {
           />
         </Heading>
 
-        {error !== null ? (
-          error.message
+        {error ? (
+          error
         ) : members === null ? (
           <SkeletonMemberCard />
         ) : members.length === 0 ? (
@@ -90,7 +90,7 @@ export const getStaticProps: GetStaticProps<Props> = async () => {
   return {
     revalidate: 100, // In Seconds
     // will be passed to the page component as props
-    props: { members, error },
+    props: { members, error: error?.message },
   };
 };
 


### PR DESCRIPTION
# Descrição

@marco-souza  I was looking at the bug that @vzsoares mentioned as it's pretty bizarre. It's basically [next js saying ](https://github.com/vercel/next.js/discussions/18897) that the props value it's not json serializable and that causes the build to fail.

Some things I want to understand:
- The page I've changed is an old code from Marco.
- At `pages/index.tsx` we have the EXACT SAME GetStaticProps function definition, and even though I didn't change anything in there the build is still working

## Changes

- Send only error message on `GetStaticProps` for `/team`

## Notes

- I'm opening this pull request mainly due to the second point I've mentioned in the description. Idk exactly yet why 
