### PR TITLE
fix: adjust getstaticprops interface

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -12,7 +12,7 @@ import { getTestimonialInstance } from '@packages/services/testimonials';
 
 interface Props {
   testimonials: Testimonial[] | null;
-  error: Error | null;
+  error: string | null;
 }
 
 export default function Home(props: Props) {
@@ -44,6 +44,6 @@ export const getStaticProps: GetStaticProps<Props> = async () => {
   return {
     revalidate: 100, // In Seconds
     // will be passed to the page component as props
-    props: { testimonials, error },
+    props: { testimonials, error: error?.message || null },
   };
 };

--- a/pages/team.tsx
+++ b/pages/team.tsx
@@ -13,7 +13,7 @@ import useEditingMode from '@packages/hooks/useEditingMode';
 
 interface Props {
   members: Member[] | null;
-  error: string | undefined;
+  error: string | null;
 }
 
 export default function Team({ members, error }: Props) {
@@ -49,7 +49,7 @@ export default function Team({ members, error }: Props) {
           />
         </Heading>
 
-        {error ? (
+        {error != null ? (
           error
         ) : members === null ? (
           <SkeletonMemberCard />
@@ -90,7 +90,7 @@ export const getStaticProps: GetStaticProps<Props> = async () => {
   return {
     revalidate: 100, // In Seconds
     // will be passed to the page component as props
-    props: { members, error: error?.message },
+    props: { members, error: error?.message || null },
   };
 };
 


### PR DESCRIPTION
# Descrição

This is a fix related to #138, apparently, undefined is also not serializable so I changed the function to return or a string or null instead of a complex object.

## Changes

- Send only error message or null on `GetStaticProps` for `/team`
- Extend the above change for `/index` also

## Notes

- @vzsoares please, try this build, I believe that new errors won't happen again

closes #139 