### PR TITLE
fix: change in mentoring links.

### DIFF
--- a/packages/components/RoadmapSection.tsx
+++ b/packages/components/RoadmapSection.tsx
@@ -84,13 +84,13 @@ const cardList: CardItemProps[] = [
     color: '#F99223',
   },
   {
-    title: 'market',
-    link: roadMapsLinks.gettingHired,
+    title: 'react',
+    link: roadMapsLinks.react,
     color: '#FF4CFF',
   },
   {
-    title: 'computing',
-    link: roadMapsLinks.computerScience,
+    title: 'data',
+    link: roadMapsLinks.introToData,
     color: '#b794f4',
   },
 ];

--- a/packages/config/site.ts
+++ b/packages/config/site.ts
@@ -30,8 +30,8 @@ export const roadMapsLinks = {
     'https://www.notion.so/podcodar/Programa-o-Web-0a244ea5a20f4b73b2c706141f7a4919',
   uxDesign:
     'https://www.notion.so/podcodar/UX-Design-f159ae7615d94d99b7a90675f608788a',
-  gettingHired:
-    'https://www.notion.so/podcodar/Entrar-no-mercado-6132c9e0873948d9943c174f66df7ee3',
-  computerScience:
-    'https://www.notion.so/podcodar/Computa-o-e7674e02bb924ea495f21575f890a831',
+  react:
+    'https://www.notion.so/Em-Constru-o-Programa-o-Web-React-15026eb75eae4dfc8bcb796eb5ef7c7f',
+  introToData:
+    'https://www.notion.so/Introdu-o-Dados-ddc04fddf7ee495a8b697263e75e9477',
 };

--- a/packages/locale/en.yml
+++ b/packages/locale/en.yml
@@ -60,8 +60,8 @@ roadmap:
   see-all: See all
   web-programming: Web Programming
   ux-design: UX Design
-  market: Getting hired
-  computing: Computing
+  react: React
+  data: Intro to data
   tech-title: Technologies
 
 footer:

--- a/packages/locale/pt.yml
+++ b/packages/locale/pt.yml
@@ -51,8 +51,8 @@ roadmap:
   see-all: Ver todas
   web-programming: Programação Web
   ux-design: UX Design
-  market: Entrar no mercado
-  computing: Computação
+  react: React
+  data: Introdução à dados
   tech-title: Tecnologias
 
 testimonials:


### PR DESCRIPTION
# Description

- It fixed the broken links of mentorships

## Changes

- The mentoring "Entrar no mercado" was replaced by React.
- The mentoring "Computação" was replaced by Introdução à Dados.

## Notes

- The options modified can be changed in case some option do not be good
