### PR TITLE
feat: disable join modal

### DIFF
--- a/packages/components/CallToActionSection.tsx
+++ b/packages/components/CallToActionSection.tsx
@@ -1,7 +1,6 @@
 import { Button, Flex, Heading, Stack, Text } from '@chakra-ui/react';
 import { Trans } from 'react-i18next';
 
-import { useModalActions } from '@packages/features/modal-context';
 import { Illustration } from '@packages/components/icons';
 import { useI18n } from '@packages/features/i18n-context';
 import { links } from '@packages/config/site';
@@ -9,8 +8,8 @@ import { links } from '@packages/config/site';
 import Section from './Section';
 
 export default function CallToActionSection() {
-  const { open } = useModalActions();
   const { t } = useI18n('call-to-action');
+
   return (
     <Section py="10rem">
       <Stack textAlign="center" align="center" spacing={{ base: 8, md: 10 }}>
@@ -26,24 +25,16 @@ export default function CallToActionSection() {
             }}
           />
         </Heading>
+
         <Text color="gray.500" maxW="3xl">
           {t(`description`)}
         </Text>
+
         <Stack
           spacing={6}
           w={{ base: '100%', sm: 'auto' }}
           direction={{ base: 'column', sm: 'row' }}
         >
-          <Button
-            rounded="full"
-            px={6}
-            colorScheme="purple"
-            bg="purple.400"
-            _hover={{ bg: 'purple.500' }}
-            onClick={open}
-          >
-            {t(`main-button`)}
-          </Button>
           <Button as="a" href={links.secondaryButton} rounded="full" px={6}>
             {t(`secondary-button`)}
           </Button>

--- a/packages/components/Layout.tsx
+++ b/packages/components/Layout.tsx
@@ -1,8 +1,6 @@
 import { Box } from '@chakra-ui/layout';
 import { ReactNode } from 'react';
 
-import CallToActionModal from '@packages/components/dialogs/CallToActionModal';
-
 import NavBar from './NavBar';
 
 interface Props {
@@ -12,7 +10,6 @@ interface Props {
 function Layout({ children }: Props) {
   return (
     <Box>
-      <CallToActionModal />
       <NavBar />
       {children}
     </Box>

--- a/packages/components/NavBar.tsx
+++ b/packages/components/NavBar.tsx
@@ -10,12 +10,12 @@ import {
   useDisclosure,
   HStack,
   useColorModeValue,
+  Tooltip,
 } from '@chakra-ui/react';
 import { HamburgerIcon, CloseIcon } from '@chakra-ui/icons';
 import { useMemo } from 'react';
 
 import { Logo } from '@packages/components/icons';
-import { useModalActions } from '@packages/features/modal-context';
 import { useI18n } from '@packages/features/i18n-context';
 import { links } from '@packages/config/site';
 import Link from '@packages/components/Link';
@@ -32,7 +32,6 @@ const actionButtons = [
 
 function NavBar() {
   const { t } = useI18n('navbar');
-  const { open } = useModalActions();
   const { isOpen, onOpen, onClose } = useDisclosure();
   const navbarBgColor = useColorModeValue('gray.50', 'gray.900');
 
@@ -97,16 +96,26 @@ function NavBar() {
           </HStack>
         </Flex>
 
-        <Button
-          key="cta"
-          minW="5rem"
-          colorScheme="purple"
+        <Tooltip
+          hasArrow
+          shouldWrapChildren
+          w={40}
           bg="purple.400"
-          _hover={{ bg: 'purple.500' }}
-          onClick={open}
+          fontWeight="bold"
+          textAlign="center"
+          label={t(`join.tooltip`)}
         >
-          {t(`join`)}
-        </Button>
+          <Button
+            isDisabled
+            key="cta"
+            minW="5rem"
+            bg="purple.400"
+            colorScheme="purple"
+            _hover={{ bg: 'purple.500' }}
+          >
+            {t(`join`)}
+          </Button>
+        </Tooltip>
       </Container>
 
       {isOpen ? (

--- a/packages/components/dialogs/CallToActionModal.tsx
+++ b/packages/components/dialogs/CallToActionModal.tsx
@@ -1,3 +1,6 @@
+// (Frattezi) FEATURE TEMPORARILY PAUSED: This functionality is currently on hold.
+// If you need to restore its usage, please check PR https://github.com/podcodar/webapp/pull/149/.
+
 import {
   Modal,
   ModalBody,

--- a/packages/locale/en.yml
+++ b/packages/locale/en.yml
@@ -11,7 +11,6 @@ call-to-action:
     We are a technology and work community that teaches programming with a focus
     on training professionals. We exist to democratize knowledge and access to job
     opportunities in the technology area
-  main-button: Join us!
   secondary-button: Learn more
 
 why-it-works:

--- a/packages/locale/en.yml
+++ b/packages/locale/en.yml
@@ -1,5 +1,6 @@
 navbar:
   join: Join
+  join.tooltip: Registrations paused. More information coming soon!
   forum: Forum
   wiki: Wiki
   team: Team

--- a/packages/locale/pt.yml
+++ b/packages/locale/pt.yml
@@ -1,5 +1,6 @@
 navbar:
   join: Entrar
+  join.tooltip: Incrições pausadas. Em breve, mais informações!
   forum: Fórum
   wiki: Wiki
   team: Equipe

--- a/packages/locale/pt.yml
+++ b/packages/locale/pt.yml
@@ -12,7 +12,6 @@ call-to-action:
     com foco na formação de profissionais. Existimos para democratizar o
     conhecimento e o acesso às oportunidades de trabalho na área de
     tecnologia
-  main-button: Faça parte!
   secondary-button: Saiba mais
 
 why-it-works:


### PR DESCRIPTION
# Description

Quick PR disabling the "join PodCodar" feature on the website, as decided by the board.

## Changes

- Remove `CallToActionModal` usage and disable Join button at the `NavBar`.
- Remove call-to-action button `Join Us`
- Add informative tooltip.

