### PR TITLE
[ref] Migrate Footer component

### DIFF
--- a/packages/components/Footer.tsx
+++ b/packages/components/Footer.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import Image from 'next/image'
+
 import { Logo } from "@packages/components/icons";
 import { PIX_KEY, images } from "@packages/config/site";
 import { useI18n } from "@packages/features/i18n-context";
@@ -33,7 +35,7 @@ function Pix() {
     <div className="flex flex-col items-center gap-2">
       <p>{t("contribution")}</p>
       <p className="text-sm text-zinc-500">{PIX_KEY}</p>
-      <img src={images.pixQRCode} width="40%" alt={t("contribution")} />
+      <Image src={images.pixQRCode} width={125} height={125} alt={t("contribution")} />
     </div>
   );
 }

--- a/packages/components/Footer.tsx
+++ b/packages/components/Footer.tsx
@@ -10,7 +10,7 @@ import SocialIconLinks from "./SocialIconLinks";
 export default function Footer() {
   return (
     <Section className="bg-neutral-950 px-6 py-6 items-center">
-      <div className="grid grid-cols-3 text-gray-50">
+      <div className="grid grid-cols-1 sm:grid-cols-3 text-gray-50">
         <PodCodarLogo />
         <Copyrights />
         <Pix />

--- a/packages/components/Footer.tsx
+++ b/packages/components/Footer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Image from 'next/image'
+import Image from "next/image";
 
 import { Logo } from "@packages/components/icons";
 import { PIX_KEY, images } from "@packages/config/site";

--- a/packages/components/Footer.tsx
+++ b/packages/components/Footer.tsx
@@ -1,11 +1,8 @@
 "use client";
 
-import { Stack, Text, Image, Grid } from "@chakra-ui/react";
-import { css } from "@emotion/react";
-
-import { useI18n } from "@packages/features/i18n-context";
-import { PIX_KEY, images } from "@packages/config/site";
 import { Logo } from "@packages/components/icons";
+import { PIX_KEY, images } from "@packages/config/site";
+import { useI18n } from "@packages/features/i18n-context";
 
 import Section from "./Section";
 import SocialIconLinks from "./SocialIconLinks";
@@ -13,33 +10,31 @@ import SocialIconLinks from "./SocialIconLinks";
 export default function Footer() {
   return (
     <Section className="bg-neutral-950 px-6 py-6 items-center">
-      <Grid gridTemplateColumns={{ base: "1fr", sm: "repeat(3, 1fr)" }} color="gray.50" css={centerGridCells}>
+      <div className="grid grid-cols-3 text-gray-50">
         <PodCodarLogo />
         <Copyrights />
         <Pix />
-      </Grid>
+      </div>
     </Section>
   );
 }
 
 function PodCodarLogo() {
   return (
-    <Stack>
+    <div className="flex flex-col items-center gap-2">
       <Logo size="large" />
-    </Stack>
+    </div>
   );
 }
 
 function Pix() {
   const { t } = useI18n("footer");
   return (
-    <Stack>
-      <Text>{t("contribution")}</Text>
-      <Text fontSize="sm" color="#718096">
-        {PIX_KEY}
-      </Text>
-      <Image src={images.pixQRCode} width="40%" alt={t("contribution")} />
-    </Stack>
+    <div className="flex flex-col items-center gap-2">
+      <p>{t("contribution")}</p>
+      <p className="text-sm text-zinc-500">{PIX_KEY}</p>
+      <img src={images.pixQRCode} width="40%" alt={t("contribution")} />
+    </div>
   );
 }
 
@@ -47,18 +42,10 @@ function Copyrights() {
   const { t } = useI18n("footer");
   const currentYear = new Date().getFullYear();
   return (
-    <Stack>
-      <Text>{t("podcodar")}</Text>
-
+    <div className="flex flex-col items-center gap-2">
+      <p>{t("podcodar")}</p>
       <SocialIconLinks />
-
-      <Text fontSize="sm">{t("legal", { currentYear })}</Text>
-    </Stack>
+      <p className="text-sm">{t("legal", { currentYear })}</p>
+    </div>
   );
 }
-
-const centerGridCells = css`
-  & > * {
-    align-items: center;
-  }
-`;


### PR DESCRIPTION
# Description

This PR migrates the `Footer` component from Chakra UI to Tailwind CSS and Daisy UI, maintaining the original structure and visual design.

## Changes

- [x] Removed all Chakra UI components from the `Footer`
- [x] Maintained the original structure while adapting to Tailwind CSS and Daisy UI

## Preview

> ![print](https://github.com/user-attachments/assets/1e5648b2-613b-48f5-811f-0f5320f2f724)

## Issues

- **Epic:** #164
  - [x] **Closes:** #187 