### PR TITLE
[ref] Migrate TechSection component

### DIFF
--- a/packages/components/TechSection.tsx
+++ b/packages/components/TechSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { HStack, Heading } from "@chakra-ui/react";
+import { HStack } from "@chakra-ui/react";
 
 import { useI18n } from "@packages/features/i18n-context";
 
@@ -46,9 +46,8 @@ function TechSection() {
 
   return (
     <Section>
-      <Heading my="4rem" size="md" fontWeight={600} textAlign="left">
-        {t("tech-title")}
-      </Heading>
+      <h2 className="my-16 text-xl leading-tight font-semibold text-left">{t("tech-title")}</h2>
+
       <HStack spacing="1rem" flexWrap="wrap" justifyContent="center" alignItems="center" lineHeight="200%">
         {iconList.map((Icon) => (
           <Icon p="0.3rem" key={Icon.name} />

--- a/packages/components/TechSection.tsx
+++ b/packages/components/TechSection.tsx
@@ -1,11 +1,15 @@
 "use client";
 
+import { classes } from "@packages/utils/classes";
 import { useI18n } from "@packages/features/i18n-context";
 
 import {
+  CssIcon,
   DockerIcon,
   GitIcon,
+  HtmlIcon,
   JavaScriptIcon,
+  LinuxIcon,
   NextIcon,
   NodeIcon,
   PythonIcon,
@@ -14,11 +18,9 @@ import {
   ShellIcon,
   SqlIcon,
   TypeScriptIcon,
-  LinuxIcon,
   WebPackIcon,
-  HtmlIcon,
-  CssIcon,
 } from "./icons";
+
 import Section from "./Section";
 
 const iconList = [
@@ -47,9 +49,11 @@ function TechSection() {
       <h2 className="mx-4 my-16 font-semibold text-left text-xl leading-tight">{t("tech-title")}</h2>
 
       <div className="flex flex-wrap mx-4 items-center justify-center">
-        {iconList.map((Icon) => (
-          <Icon className="ml-4:first-child:ml-0" p="0.3rem" key={Icon.name} />
-        ))}
+        {iconList.map((Icon, index) => {
+          const iconSpacing = classes(index > 0 && "ml-4");
+
+          return <Icon className={iconSpacing} style={{ padding: "0.3rem" }} key={Icon.name} />;
+        })}
       </div>
     </Section>
   );

--- a/packages/components/TechSection.tsx
+++ b/packages/components/TechSection.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { HStack } from "@chakra-ui/react";
-
 import { useI18n } from "@packages/features/i18n-context";
 
 import {
@@ -46,13 +44,13 @@ function TechSection() {
 
   return (
     <Section>
-      <h2 className="my-16 text-xl leading-tight font-semibold text-left">{t("tech-title")}</h2>
+      <h2 className="mx-4 my-16 font-semibold text-left text-xl leading-tight">{t("tech-title")}</h2>
 
-      <HStack spacing="1rem" flexWrap="wrap" justifyContent="center" alignItems="center" lineHeight="200%">
+      <div className="flex flex-wrap mx-4 items-center justify-center">
         {iconList.map((Icon) => (
-          <Icon p="0.3rem" key={Icon.name} />
+          <Icon className="ml-4:first-child:ml-0" p="0.3rem" key={Icon.name} />
         ))}
-      </HStack>
+      </div>
     </Section>
   );
 }


### PR DESCRIPTION
# Description

This PR migrates the `TechSection` component from Chakra UI to Tailwind CSS and Daisy UI, maintaining the original structure and visual design.

## Changes

- [x] Removed all Chakra UI components from the `TechSection`
- [x] Maintained the original structure while adapting to Tailwind CSS and Daisy UI

## Preview

> ------

## Issues

- **Epic:** #164
  - [x] **Closes:** #193 