### PR TITLE
[ref] Migrating the not-found from Chakra UI to Tailwind.

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,19 +1,13 @@
-import { Heading, Stack, Text } from "@chakra-ui/layout";
-
 import Section from "@packages/components/Section";
 
 export default function PageNotFound() {
   return (
     <Section className="px-0 pt-32">
-      <Stack textAlign="center" align="center" spacing={{ base: 2, md: 4 }}>
-        <Heading fontWeight={600} fontSize={{ base: "3xl", sm: "4xl" }} lineHeight="110%">
-          Não encontramos sua página
-        </Heading>
-        <Text color="purple.400">(╯°□°)╯︵ ┻━┻</Text>
-        <Text color="gray.500" maxW="3xl">
-          Mas encontramos esse abacate!
-        </Text>
-      </Stack>
+      <div className="flex flex-col items-center text-center space-y-2 md:space-y-4">
+        <h1 className="font-semibold text-3xl sm:text-4xl leading-tight">Não encontramos sua página</h1>
+        <p className="text-purple-400">(╯°□°)╯︵ ┻━┻</p>
+        <p className="text-gray-500 max-w-3xl">Mas encontramos esse abacate!</p>
+      </div>
     </Section>
   );
 }


### PR DESCRIPTION
# Descrição

Removing Chakra UI dependencies from the Not Found page.

## Changes

- ref: Removing components and dependencies, Heading, Stack, Text from Chakra UI.

## Preview
![Screenshot 2024-10-18 at 15 20 16](https://github.com/user-attachments/assets/862c16ce-ab62-428c-81c6-2e0819461630)

> 

Closes #217 
