### PR TITLE
[fea] Route created for transparency data

### DIFF
--- a/app/transparency/page.tsx
+++ b/app/transparency/page.tsx
@@ -1,0 +1,13 @@
+import Section from "@packages/components/Section";
+
+function Transparency() {
+  return (
+    <Section className="px-0 pt-32">
+      <div className="flex flex-col items-center text-center space-y-2 md:space-y-4">
+        <h1 className="font-semibold text-xl sm:text-3xl leading-tight py-30"> PodCodar transparency data </h1>
+      </div>
+    </Section>
+  );
+}
+
+export default Transparency;

--- a/app/transparency/page.tsx
+++ b/app/transparency/page.tsx
@@ -3,8 +3,8 @@ import Section from "@packages/components/Section";
 function Transparency() {
   return (
     <Section className="px-0 pt-32">
-      <div className="flex flex-col items-center text-center space-y-2 md:space-y-4">
-        <h1 className="font-semibold text-xl sm:text-3xl leading-tight py-30"> PodCodar transparency data </h1>
+      <div className="flex flex-col items-center space-y-2 text-center md:space-y-4">
+        <h1 className=" py-30 font-semibold text-xl leading-tight sm:text-3xl "> PodCodar transparency data </h1>
       </div>
     </Section>
   );


### PR DESCRIPTION
# Descrição

Route created to handle transparency data

## Changes

- fea: Route created

## Preview
<img width="1412" alt="Screenshot 2024-11-27 at 09 39 49" src="https://github.com/user-attachments/assets/87169e15-c577-4e24-aac0-c1e39a684019">


This closes #152